### PR TITLE
This PR Fix 'M3_SerialManipulatorEDH::set_base_frame()' not considering that a rotation r is equal to a rotation -r

### DIFF
--- a/src/example/M3_SerialManipulatorEDH.cpp
+++ b/src/example/M3_SerialManipulatorEDH.cpp
@@ -129,7 +129,9 @@ void M3_SerialManipulatorEDH::set_base_frame(const DQ &base)
     set_base_frame(base_parameters);
 
     //Verify if the rotation was correctly reconstructed
-    if((vec4(rotation(base))-vec4(rotation(get_base_frame()))).cwiseAbs().maxCoeff() > DQ_robotics::DQ_threshold)
+    DQ base_rotation = rotation(base);
+    DQ reconstructed_rotation = rotation(get_base_frame());
+    if ( ((vec4(base_rotation)-vec4(reconstructed_rotation)).cwiseAbs().maxCoeff() > DQ_robotics::DQ_threshold) && (base_rotation != -reconstructed_rotation) )
     {
         throw std::runtime_error("DQ_SerialManipulatorRDH::set_base_frame()::Error::Rotation quaternion could not be correctly reconstructed (a!=b). \n"
                                  "a= " + rotation(base).to_string() + " b=" + rotation(get_base_frame()).to_string() + "\n" +

--- a/src/example/M3_VFI.cpp
+++ b/src/example/M3_VFI.cpp
@@ -55,8 +55,7 @@ M3_VFI::M3_VFI(const std::string &workspace_entity_name,
     relative_displacement_to_joint_(relative_displacement_to_joint),
     cs_reference_name_(cs_reference_name)
 {
-    if(joint_index_ != 7)
-        throw std::runtime_error("Not implemented yet for anything besides joint_index_ == 7");
+    // Do nothing
 }
 
 void M3_VFI::initialize()


### PR DESCRIPTION
Hi @mmmarinho,

The current implementation of [M3_SerialManipulatorEDH](https://github.com/mmmarinho/tro2022_adaptivecontrol/blob/master/src/example/M3_SerialManipulatorEDH.cpp) checks whether it can successfully reconstruct the base rotation that was set with the [set_base_frame](https://github.com/mmmarinho/tro2022_adaptivecontrol/blob/4a0931908501cae971f1fcf1531be341d0916a44/src/example/M3_SerialManipulatorEDH.cpp#L131) method. However, it does not take into consideration that a rotation represented by a unit quaternion $r$ is equal to a rotation $-r$. As such, on rare occasions, I had this method return the exception 

```bash

DQ_SerialManipulatorRDH::set_base_frame()::Error::Rotation quaternion could not be correctly reconstructed (a!=b)

```

which was essentially claiming $r\ != -r$.

This PR fixes this issue by adding an extra check on 

```cpp

if((vec4(rotation(base))-vec4(rotation(get_base_frame()))).cwiseAbs().maxCoeff() > DQ_robotics::DQ_threshold)

```

to account for the fact that $r = -r$.

I don't think this inclusion breaks the purpose of this check, but let me know what you think of it.

Kind regards,
Frederico