### PR TITLE
Fix .build.sh source-tree pollution and a copyright header typo

### DIFF
--- a/.build.sh
+++ b/.build.sh
@@ -53,22 +53,26 @@ echo "Found ""${phycores}"" physical cores."
 # BUILD FUNCTION
 ##########################
 
-# The only unusual thing here is the -DCMAKE_INSTALL_PREFIX that we set
-# so everything is installed locally.
+# After `make`, the example executable is placed in `build/`. We copy it into
+# `bin/` (where `.run.sh` expects it) instead of running `make install`: the
+# in-tree dependency projects (dqrobotics, qpOASES) have their own install
+# rules that would scatter their headers/sources into the repo's `include/`
+# and `src/` when the install prefix is the repo root.
 BUILD(){
   rm -rf build
   mkdir build
   cd build || return
   # The standalone C++ build does not need a Python interpreter, so the
   # pybind11 module (built by `pip install .` through setup.py) is skipped.
-  cmake .. -DCMAKE_INSTALL_PREFIX="${repo_root_dir}" -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DBUILD_PYTHON_WRAPPER=OFF
+  cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DBUILD_PYTHON_WRAPPER=OFF
   if [ -z "$variable" ]
     then
       make -j"${phycores}"
     else
       make
   fi
-  make install
+  mkdir -p "${repo_root_dir}/bin"
+  cp "${repo_root_dir}/build/adaptive_control_cpp" "${repo_root_dir}/bin/"
 }
 
 ######################################

--- a/include/marinholab/papers/tro2022/adaptive_control/M3_SerialManipulatorEDH.h
+++ b/include/marinholab/papers/tro2022/adaptive_control/M3_SerialManipulatorEDH.h
@@ -1,6 +1,6 @@
 #pragma once
 /**
-(C) Copyright 2029-2023 Murilo Marques Marinho (www.murilomarinho.info)
+(C) Copyright 2020-2023 Murilo Marques Marinho (www.murilomarinho.info)
 
 This file is part of adaptive_control_example.
 


### PR DESCRIPTION
Two small, independent maintenance fixes found while reviewing and verifying the build.

## 1. `.build.sh` was scattering dependency headers into the source tree

`.build.sh` ran `make install` with `-DCMAKE_INSTALL_PREFIX=<repo root>`. The in-tree dependency projects (`dqrobotics`, `qpOASES`) each carry their own install rules, so that step copied their **headers into `include/` and sources into `src/` on every build** — e.g. `include/dqrobotics/`, `include/qpOASES/`, `src/dqrobotics/`. These are untracked files **not covered by `.gitignore`** (which only ignores `build/ bin/ lib/ dist/`), so a fresh `git status` after building was always dirty.

**Fix:** stop installing. After `make`, the example executable is placed in `build/`; copy it into `bin/` (where `.run.sh` expects it) and drop the now-unneeded `-DCMAKE_INSTALL_PREFIX`. `bin/` and `build/` are already gitignored, so the tree stays clean. The executable is statically linked (no in-tree shared libs), so it runs unchanged.

## 2. Copyright header typo

`include/.../M3_SerialManipulatorEDH.h`: `Copyright 2029-2023` → `2020-2023` (matching the sibling headers, which use `2020-2023` / `2020-2026`).

## Base branch note

This targets `remove-coppeliasim-headless-simulator` (the head of the open headless-simulator PR #10) so the diff is limited to exactly these two files. The same two issues also exist on `master`; if you'd prefer, I can open the equivalent PR against `master` instead.

## Verification
- `./.build.sh` (from scratch): builds in ~12 s; `git status` afterwards shows **only the two changed files** — no `include/`/`src/` pollution.
- `bin/adaptive_control_cpp` runs end-to-end (headless, steps [1]–[7]).
- Diff: 2 files changed, 9 insertions(+), 5 deletions(-).

_Created by an AI agent (OpenHands) on behalf of the user._