### PR TITLE
Python-inheritable M3_Simulator trampoline + dqrobotics-pyplot visualization backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,3 +60,17 @@ Eigen has no CMake config; the root CMakeLists therefore uses
 directory-scope `include_directories()` (APPLE-gated) so the path reaches
 every target (lib, exe, `_core`). `find_package(Eigen3)` is unreliable and
 was removed. Linux is unaffected (`/usr/include/eigen3` via libeigen3-dev).
+
+## matplotlib / animation gotchas (3.x)
+- To detect a 3d axes use `isinstance(ax, Axes3D)` — the old
+  `hasattr(ax, 'proj3d')` check is **always False** on mpl 3.x (the `proj3d`
+  property was removed); the buggy check made every `draw_scene` call create
+  a NEW 3d axes and leak one per call.
+- `plt.axes(projection='3d')` always creates a NEW axes even if a 3d one is
+  current — never a reuse. Capture the returned object or reuse the existing
+  one explicitly.
+- `M3_PyPlotSimulator.draw_scene` is idempotent (static scene drawn once per
+  axes, only the robot is redrawn afterwards) and
+  `M3_PyPlotSimulator.animation(q, ...)` builds a `FuncAnimation` on top of
+  that (static drawn once, robot-only redraw per frame). GIF always works via
+  `PillowWriter`; mp4 etc. need ffmpeg on PATH.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,4 +73,7 @@ was removed. Linux is unaffected (`/usr/include/eigen3` via libeigen3-dev).
   axes, only the robot is redrawn afterwards) and
   `M3_PyPlotSimulator.animation(q, ...)` builds a `FuncAnimation` on top of
   that (static drawn once, robot-only redraw per frame). GIF always works via
-  `PillowWriter`; mp4 etc. need ffmpeg on PATH.
+  `PillowWriter`; mp4/avi etc. need ffmpeg on PATH (uses `FFMpegWriter`).
+- matplotlib's `Animation.__init__` **rejects `fps`** (it belongs to
+  `Animation.save`). If you build a `FuncAnimation` from user kwargs, pop
+  `fps` before the constructor and only pass it to `.save(...)`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,14 @@ Single-tree layout, consolidated from the old `python_wrapper/` design:
 - `dqrobotics` + wrapper share `__pybind11_internals_v11`
   (pybind11 v3.0 branch pinned in `dqrobotics/python/.gitmodules`).
 
+## Code style
+- Prefer the `dqrobotics` functions over numpy wherever they exist (in Python:
+  `dot`, `cross`, `norm`, `translation`, `rotation`, `Ad`, `DQ.normalize()`,
+  and the `DQ()` constructor — `DQ([x,y,z])` builds a pure quaternion from a
+  3-vector). Keep vectors as `DQ` end-to-end instead of bouncing through
+  numpy. Note: `DQ.normalize()` returns a **new** normalized DQ (not in-place);
+  the dual unit satisfies `E_*E_ == 0` (nilpotent, not `-1`).
+
 ## Verified commands
 - C++: `./build/adaptive_control_cpp` → steps [1]-[7], adaptation error
   ~0.13 m final.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(adaptive_control
         src/example/M3_AdaptiveController.cpp
         src/example/M3_VFI.cpp
         src/example/M3_SerialManipulatorEDH.cpp
+        src/example/M3_Simulator.cpp
         src/example/M3_SimulatorDummy.cpp
         src/example/M3_MeasurementSpace.cpp
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,32 @@
     python3 -m pip install marinholab-papers-tro2022-adaptivecontrol --break-system-packages
 ```
 
+### Optional scene visualization
+
+The `M3_Simulator` base class (which `M3_SimulatorDummy` derives from) can be
+subclassed in Python to provide a scene-visualization backend. The package
+ships `M3_PyPlotSimulator`, which loads a scene from YAML and draws it with
+[`dqrobotics-pyplot`](https://pypi.org/project/dqrobotics-pyplot/):
+
+```commandline
+    python3 -m pip install "marinholab-papers-tro2022-adaptivecontrol[viz]"
+```
+
+```python
+from marinholab.papers.tro2022.adaptive_control import M3_PyPlotSimulator
+import matplotlib.pyplot as plt
+
+sim = M3_PyPlotSimulator()
+sim.load_scene("scenes/example.yaml")   # robot + walls + tubes + targets
+fig = plt.figure(); plt.axes(projection="3d")
+sim.draw_scene()                        # overrides M3_Simulator.draw_scene()
+plt.show()
+```
+
+`M3_VFI` accepts any `M3_Simulator` subclass (it holds a
+`std::shared_ptr<M3_Simulator>`), so the visualization backend can be used
+directly with the adaptive controller.
+
 ## Reference
 
 Sample code and minimal example for [our TRO2022 paper](https://doi.org/10.1109/TRO.2022.3181047).

--- a/include/marinholab/papers/tro2022/adaptive_control/M3_Simulator.h
+++ b/include/marinholab/papers/tro2022/adaptive_control/M3_Simulator.h
@@ -1,0 +1,132 @@
+#pragma once
+/**
+(C) Copyright 2020-2026 Murilo Marques Marinho (www.murilomarinho.info)
+
+This file is part of adaptive_control_example.
+
+    DQ Robotics is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    adaptive_control_example is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with adaptive_control_example.  If not, see <http://www.gnu.org/licenses/>.
+
+Author:
+    Murilo M. Marinho (murilomarinho@ieee.org)
+
+Contributors (aside from author):
+    None
+*/
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <dqrobotics/DQ.h>
+#include <dqrobotics/utils/DQ_Geometry.h>
+#include <dqrobotics/utils/DQ_Math.h>
+
+using namespace DQ_robotics;
+
+/**
+ * @brief M3_Simulator is the base class of a robot-scene simulator.
+ *
+ * It stores the state of a named set of scene objects (each given by a DQ
+ * pose) plus the robot configuration (joint-space), and tracks whether the
+ * simulation has been started.
+ *
+ * The interface is intentionally minimal and backend-agnostic: a concrete
+ * backend provides the scene data and may override the virtual @ref draw_scene
+ * for visualization. The headless, in-memory backend is M3_SimulatorDummy; a
+ * visualization backend (based on dqrobotics_extensions.pyplot) is provided on
+ * the Python side (M3_PyPlotSimulator).
+ *
+ * This class is exposed to Python together with a pybind11 trampoline so that
+ * it can be subclassed from Python (a Python subclass overrides draw_scene).
+ * It deliberately has no pybind11/Python-API dependency so that the pure C++
+ * (headless) build stays free of any Python runtime.
+ */
+class M3_Simulator
+{
+    //Object poses, keyed by object name
+    std::unordered_map<std::string, DQ> object_poses_;
+
+    //Robot configuration (joint-space)
+    VectorXd q_ = VectorXd::Zero(6);
+
+    //Simulation state (the loop always runs in real time)
+    bool running_ = false;
+
+public:
+    M3_Simulator() = default;
+
+    // A polymorphic base class needs a virtual destructor so that a
+    // std::shared_ptr<M3_Simulator> can safely destroy a derived object.
+    virtual ~M3_Simulator() = default;
+
+    /**
+     * @brief draw_scene Draws the scene (robots, obstacles, targets). This is
+     * the visualization hook that a backend (e.g. the Python-side
+     * M3_PyPlotSimulator) is expected to override; it is exposed through a
+     * pybind11 trampoline so a Python subclass can override it. The default
+     * (headless) implementation does nothing.
+     *
+     * The method takes no arguments on purpose, so this C++ base class stays
+     * free of any Python dependency (the pure headless build links no Python
+     * runtime). A visualization backend renders onto the current plot Axes
+     * (or a stored one), matching the dqrobotics_extensions.pyplot convention
+     * of defaulting to matplotlib's current axes.
+     */
+    virtual void draw_scene();
+
+    //*************** Object poses (the "scene") ***************
+
+    /**
+     * @brief get_object_pose Returns the pose of @p object_name.
+     * @param object_name the name of the object.
+     * @throws std::runtime_error if the object does not exist in the scene.
+     */
+    DQ get_object_pose(const std::string& object_name) const;
+
+    /**
+     * @brief get_object_pose_or_default Returns the pose of @p object_name, or
+     * @p default_pose if the object does not exist.
+     */
+    DQ get_object_pose_or_default(const std::string& object_name, const DQ& default_pose) const;
+
+    /**
+     * @brief set_object_pose Sets the pose of @p object_name (creating it if new).
+     */
+    void set_object_pose(const std::string& object_name, const DQ& pose);
+
+    /// Whether an object with @p object_name exists in the scene.
+    bool has_object(const std::string& object_name) const;
+
+    /// The names of all objects currently in the scene (order not guaranteed).
+    std::vector<std::string> get_object_names() const;
+
+    //*************** Robot configuration ***************
+
+    /// The current robot configuration (joint-space).
+    const VectorXd& get_configuration_space_positions() const;
+
+    /// Sets the robot configuration (joint-space).
+    void set_configuration_space_positions(const VectorXd& q);
+
+    //*************** Simulation control ***************
+
+    /// Marks the simulation as started (no real time-stepping is performed).
+    void start_simulation();
+
+    /// Marks the simulation as stopped.
+    void stop_simulation();
+
+    /// Whether the simulation is currently started.
+    bool is_running() const;
+};

--- a/include/marinholab/papers/tro2022/adaptive_control/M3_SimulatorDummy.h
+++ b/include/marinholab/papers/tro2022/adaptive_control/M3_SimulatorDummy.h
@@ -33,6 +33,7 @@ Contributors (aside from author):
 #include <dqrobotics/utils/DQ_Math.h>
 
 #include "marinholab/papers/tro2022/adaptive_control/M3_SerialManipulatorEDH.h"
+#include "marinholab/papers/tro2022/adaptive_control/M3_Simulator.h"
 
 using namespace DQ_robotics;
 
@@ -40,78 +41,25 @@ using namespace DQ_robotics;
  * @brief M3_SimulatorDummy is an in-memory stand-in for a real robot simulator
  * that stores named object poses and robot configurations.
  *
- * It exists so that the adaptive control example can be built and run
- * **headless** (no simulator, no network) for dry testing.
- *
- * The interface is intentionally minimal:
- *  - named object poses (DQ), the same concept the simulator exposed
- *    (e.g. "xd0", "xd1", "tool_sphere_1", "cube_40x40_wall_1", "x_hat");
- *  - robot configuration (joint-space) storage;
- *  - simulation start/stop bookkeeping (the loop runs in real time).
+ * It inherits from M3_Simulator (which owns the scene-object store, the
+ * configuration and the start/stop bookkeeping) so that the example can be
+ * built and run **headless** (no simulator, no network) for dry testing.
  *
  * It also ships a **nominal TRO2022 reference scene** (see load_reference_scene).
  * Note: this is a *reconstruction* of the original reference scene for dry
  * testing. The box, targets, and initial configuration are approximate, and
  * the joint limits may be adjusted per experiment.
  *
- * A future real-simulator backend can implement the same interface;
- * M3_SimulatorDummy itself is that backend for the headless case.
+ * It is a headless backend of M3_Simulator: it does not override draw_scene,
+ * so the (default) headless behavior (nothing drawn) applies. A visualization
+ * backend instead loads a scene (e.g. from a .yaml file) and overrides
+ * draw_scene, e.g. the Python-side M3_PyPlotSimulator.
  */
-class M3_SimulatorDummy
+class M3_SimulatorDummy : public M3_Simulator
 {
-    //Object poses, keyed by object name (as used in the original scene)
-    std::unordered_map<std::string, DQ> object_poses_;
-
-    //Robot configuration (joint-space)
-    VectorXd q_ = VectorXd::Zero(6);
-
-    //Simulation state (the loop always runs in real time)
-    bool running_ = false;
-
 public:
     /// Default constructor: empty scene, zero configuration.
     M3_SimulatorDummy() = default;
-
-    //*************** Object poses (the "scene") ***************
-
-    /**
-     * @brief get_object_pose Returns the pose of @p object_name.
-     * @param object_name the name of the object (as in the original scene).
-     * @throws std::runtime_error if the object does not exist in the scene.
-     */
-    DQ get_object_pose(const std::string& object_name) const;
-
-    /**
-     * @brief set_object_pose Sets the pose of @p object_name (creating it if new).
-     * @param object_name the name of the object.
-     * @param pose the pose to set.
-     */
-    void set_object_pose(const std::string& object_name, const DQ& pose);
-
-    /// Whether an object with @p object_name exists in the scene.
-    bool has_object(const std::string& object_name) const;
-
-    /// The names of all objects currently in the scene (order not guaranteed).
-    std::vector<std::string> get_object_names() const;
-
-    //*************** Robot configuration ***************
-
-    /// The current robot configuration (joint-space).
-    const VectorXd& get_configuration_space_positions() const;
-
-    /// Sets the robot configuration (joint-space).
-    void set_configuration_space_positions(const VectorXd& q);
-
-    //*************** Simulation control ***************
-
-    /// Marks the simulation as started (no real time-stepping is performed).
-    void start_simulation();
-
-    /// Marks the simulation as stopped.
-    void stop_simulation();
-
-    /// Whether the simulation is currently started.
-    bool is_running() const;
 
     //*************** Scene presets (dry testing) ***************
 

--- a/include/marinholab/papers/tro2022/adaptive_control/M3_VFI.h
+++ b/include/marinholab/papers/tro2022/adaptive_control/M3_VFI.h
@@ -28,7 +28,7 @@ Contributors (aside from author):
 #include<string>
 
 #include<dqrobotics/DQ.h>
-#include "marinholab/papers/tro2022/adaptive_control/M3_SimulatorDummy.h"
+#include "marinholab/papers/tro2022/adaptive_control/M3_Simulator.h"
 
 using namespace DQ_robotics;
 
@@ -83,7 +83,7 @@ class M3_VFI
     std::string robot_entity_name_;
     M3_Primitive type_;
     DQ value_;
-    std::shared_ptr<M3_SimulatorDummy> vi_;
+    std::shared_ptr<M3_Simulator> vi_;
     double safe_distance_;
     M3_VFI_Direction vfi_direction_;
     const int joint_index_; //Needs to be correctly implemented in the future
@@ -97,7 +97,7 @@ public:
     M3_VFI(const std::string& workspace_entity_name,
                     const std::string& robot_entity_name,
                     const M3_Primitive& type,
-                    const std::shared_ptr<M3_SimulatorDummy>& vi,
+                    const std::shared_ptr<M3_Simulator>& vi,
                     const double& safe_distance,
                     const M3_VFI_Direction& vfi_direction,
                     const int& joint_index,

--- a/marinholab/papers/tro2022/adaptive_control/__init__.py
+++ b/marinholab/papers/tro2022/adaptive_control/__init__.py
@@ -1,3 +1,8 @@
 from dqrobotics import *
 from dqrobotics.robot_modeling import DQ_SerialManipulator
 from marinholab.papers.tro2022.adaptive_control._core import *
+
+# Scene loading (YAML) and a pyplot-based M3_Simulator visualization backend.
+# (Lazy-safe: importing this package does not require matplotlib /
+# dqrobotics-pyplot; they are only needed when M3_PyPlotSimulator is used.)
+from .scene import Scene, load_scene, M3_PyPlotSimulator

--- a/marinholab/papers/tro2022/adaptive_control/__init__.py
+++ b/marinholab/papers/tro2022/adaptive_control/__init__.py
@@ -5,4 +5,8 @@ from marinholab.papers.tro2022.adaptive_control._core import *
 # Scene loading (YAML) and a pyplot-based M3_Simulator visualization backend.
 # (Lazy-safe: importing this package does not require matplotlib /
 # dqrobotics-pyplot; they are only needed when M3_PyPlotSimulator is used.)
-from .scene import Scene, load_scene, M3_PyPlotSimulator
+# ``plane`` and ``line`` build the VFI-convention primitive DQs:
+#   plane(position, normal)    ->  normal + E*dot(position, normal)
+#   line(position, direction)  ->  direction + E*cross(position, direction)
+# (they match what M3_VFI constructs internally).
+from .scene import Scene, load_scene, M3_PyPlotSimulator, plane, line

--- a/marinholab/papers/tro2022/adaptive_control/__init__.py
+++ b/marinholab/papers/tro2022/adaptive_control/__init__.py
@@ -5,8 +5,10 @@ from marinholab.papers.tro2022.adaptive_control._core import *
 # Scene loading (YAML) and a pyplot-based M3_Simulator visualization backend.
 # (Lazy-safe: importing this package does not require matplotlib /
 # dqrobotics-pyplot; they are only needed when M3_PyPlotSimulator is used.)
-# ``plane`` and ``line`` build the VFI-convention primitive DQs:
-#   plane(position, normal)    ->  normal + E*dot(position, normal)
-#   line(position, direction)  ->  direction + E*cross(position, direction)
+# ``plane`` and ``line`` build the VFI-convention primitive DQs from pure
+# quaternions: ``n``/``l`` (unit normal/direction) and ``p`` (a point on the
+# primitive, i.e. a translation):
+#   plane(n, p)  ->  n + E*dot(p, n)
+#   line(l, p)   ->  l + E*cross(p, l)
 # (they match what M3_VFI constructs internally).
 from .scene import Scene, load_scene, M3_PyPlotSimulator, plane, line

--- a/marinholab/papers/tro2022/adaptive_control/scene.py
+++ b/marinholab/papers/tro2022/adaptive_control/scene.py
@@ -117,14 +117,18 @@ def _frame_pose(r: DQ, t: DQ) -> DQ:
     return r + 0.5 * E_ * t * r
 
 
-def plane(position: DQ, normal: DQ) -> DQ:
-    """Plane DQ (VFI convention) for unit ``normal`` through ``position``."""
-    return normal + E_ * dot(position, normal)
+def plane(n: DQ, p: DQ) -> DQ:
+    """Plane DQ (VFI convention) for a unit normal ``n`` through the point
+    ``p``. ``n`` and ``p`` are pure quaternions (``p`` is a translation, i.e.
+    a point on the plane)."""
+    return n + E_ * dot(p, n)
 
 
-def line(position: DQ, direction: DQ) -> DQ:
-    """Line DQ (VFI convention) for unit ``direction`` through ``position``."""
-    return direction + E_ * cross(position, direction)
+def line(l: DQ, p: DQ) -> DQ:
+    """Line DQ (VFI convention) for a unit direction ``l`` through the point
+    ``p``. ``l`` and ``p`` are pure quaternions (``p`` is a translation, i.e.
+    a point on the line)."""
+    return l + E_ * cross(p, l)
 
 
 def load_scene(path: str, sim: M3_Simulator) -> Scene:
@@ -174,22 +178,22 @@ def load_scene(path: str, sim: M3_Simulator) -> Scene:
         points.append((name, float(p.get("radius", 0.02)), p.get("color", "b")))
 
     planes: List[Tuple[str, DQ, str]] = []
-    for p in data.get("planes", []) or []:
-        name = p["name"]
-        normal = _unit(p["normal"])
-        p0 = DQ(np.asarray(p["position"], dtype=float))
+    for pl in data.get("planes", []) or []:
+        name = pl["name"]
+        normal = _unit(pl["normal"])
+        p0 = DQ(np.asarray(pl["position"], dtype=float))
         r = _rotation_quat_between(DQ([0.0, 0.0, 1.0]), normal)
         sim.set_object_pose(name, _frame_pose(r, p0))
-        planes.append((name, plane(p0, normal), p.get("color", "g")))
+        planes.append((name, plane(normal, p0), pl.get("color", "g")))
 
     lines: List[Tuple[str, DQ, str]] = []
-    for l in data.get("lines", []) or []:
-        name = l["name"]
-        d_vec = _unit(l["direction"])
-        p0 = DQ(np.asarray(l["position"], dtype=float))
+    for ln in data.get("lines", []) or []:
+        name = ln["name"]
+        d_vec = _unit(ln["direction"])
+        p0 = DQ(np.asarray(ln["position"], dtype=float))
         r = _rotation_quat_between(DQ([0.0, 0.0, 1.0]), d_vec)
         sim.set_object_pose(name, _frame_pose(r, p0))
-        lines.append((name, line(p0, d_vec), l.get("color", "r")))
+        lines.append((name, line(d_vec, p0), ln.get("color", "r")))
 
     q0 = None
     if "q0" in data:

--- a/marinholab/papers/tro2022/adaptive_control/scene.py
+++ b/marinholab/papers/tro2022/adaptive_control/scene.py
@@ -1,0 +1,299 @@
+"""
+Scene loading (YAML) and a pyplot-based visualization backend for M3_Simulator.
+
+A scene file (YAML) describes the robot(s), the environment (planes, lines) and
+the task targets (points) of a TRO2022-style adaptive-control example. It is
+loaded into a :class:`M3_Simulator` (named object poses + robot configuration)
+and can be drawn with :class:`M3_PyPlotSimulator`, which uses
+``dqrobotics_extensions.pyplot`` (matplotlib).
+
+Scene file format
+-----------------
+::
+
+    robots:
+      - name: vs050            # object name for the robot base frame
+        dh:                    # 5 x n DH matrix: [theta; d; a; alpha; offset]
+          - [theta_1, theta_2, ...]
+          - [d_1,    d_2,    ...]
+          - [a_1,    a_2,    ...]
+          - [alpha_1, alpha_2, ...]
+          - [offset_1, offset_2, ...]
+        limits:                # optional
+          lower: [-170, -100, -60, -265, -119, -355]
+          upper: [ 170,  100, 124,  265,   89.9, 355]
+          unit: deg            # 'deg' (default) or 'rad'
+        base: [0, 0, 0]        # optional base-frame translation
+        effector: [0, 0, 0]    # optional effector-frame translation
+    points:
+      - name: xd0
+        pos: [0.0, 0.0, 0.0]
+        radius: 0.03           # optional (default 0.02)
+        color: 'g'             # optional
+    planes:
+      - name: wall_1           # plane with unit `normal` through `position`
+        position: [0.2, 0.0, 0.0]
+        normal:   [-1.0, 0.0, 0.0]
+        color: 'g'             # optional
+    lines:
+      - name: tube_1           # line with unit `direction` through `position`
+        position: [0.0, 0.12, 0.0]
+        direction: [0.0, 0.0, 1.0]
+        color: 'r'             # optional
+    q0: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]   # optional initial configuration (rad)
+
+Conventions match :class:`M3_VFI`: a plane is defined by a point (``position``)
+and a (unit) normal (``normal``); a line by a point (``position``) and a (unit)
+direction (``direction``). Each primitive is also stored on the simulator as a
+frame pose whose k-axis is the normal/direction and whose origin is the
+``position``, so a :class:`M3_VFI` built from that object pose reconstructs the
+same primitive.
+"""
+
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from dqrobotics import *
+from marinholab.papers.tro2022.adaptive_control._core import (
+    M3_SerialManipulatorEDH,
+    M3_Simulator,
+)
+
+
+@dataclass
+class Scene:
+    """A parsed scene file loaded into a simulator.
+
+    Attributes:
+        robots: (name, M3_SerialManipulatorEDH) pairs.
+        points: (name, radius, color) pairs (position is in the simulator).
+        planes: (name, plane DQ, color) triples.
+        lines: (name, line DQ, color) triples.
+        q0: optional initial configuration (radians) or None.
+        sim: the simulator the scene was loaded into.
+    """
+
+    robots: List[Tuple[str, M3_SerialManipulatorEDH]]
+    points: List[Tuple[str, float, str]]
+    planes: List[Tuple[str, DQ, str]]
+    lines: List[Tuple[str, DQ, str]]
+    q0: Optional[np.ndarray]
+    sim: M3_Simulator
+
+
+def _vector_to_dq(v) -> DQ:
+    """Build a pure-vector DQ from a 3-vector ``v = [vx, vy, vz]``."""
+    v = np.asarray(v, dtype=float)
+    if v.shape != (3,):
+        raise ValueError(f"expected a 3-vector [vx, vy, vz], got {v!r}")
+    return v[0] * i_ + v[1] * j_ + v[2] * k_
+
+
+def _unit(v):
+    v = np.asarray(v, dtype=float)
+    n = np.linalg.norm(v)
+    if n < 1e-12:
+        raise ValueError("expected a non-zero vector, got a zero vector")
+    return v / n
+
+
+def _pose_from_translation(t) -> DQ:
+    """A DQ pose from a translation ``t`` and the identity rotation."""
+    t_dq = _vector_to_dq(t)
+    return DQ([1.0]) + 0.5 * E_ * t_dq * DQ([1.0])
+
+
+def _rotation_quat_between(a, b) -> DQ:
+    """Unit quaternion (as a DQ) rotating unit vector ``a`` onto unit vector ``b``."""
+    a = _unit(a)
+    b = _unit(b)
+    cosang = float(np.clip(np.dot(a, b), -1.0, 1.0))
+    if cosang > 1.0 - 1e-12:            # same direction: identity
+        return DQ([1.0, 0.0, 0.0, 0.0])
+    if cosang < -1.0 + 1e-12:           # opposite: 180 deg about an orthogonal axis
+        tmp = np.array([1.0, 0.0, 0.0]) if abs(a[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
+        v = np.cross(a, tmp)
+        return DQ([0.0, v[0], v[1], v[2]])
+    v = np.cross(a, b)
+    vhat = v / np.linalg.norm(v)
+    half_cos = float(np.sqrt((1.0 + cosang) / 2.0))
+    half_sin = float(np.sqrt((1.0 - cosang) / 2.0))
+    return DQ([half_cos, vhat[0] * half_sin, vhat[1] * half_sin, vhat[2] * half_sin])
+
+
+def _frame_pose(r: DQ, t) -> DQ:
+    """A frame pose: rotation ``r`` (unit quaternion DQ) + translation ``t``."""
+    return r + 0.5 * E_ * _vector_to_dq(t) * r
+
+
+def _plane_dq(position, normal) -> DQ:
+    """Plane DQ (VFI convention) for unit ``normal`` through ``position``."""
+    n_dq = _vector_to_dq(normal)
+    return n_dq + E_ * dot(_vector_to_dq(position), n_dq)
+
+
+def _line_dq(position, direction) -> DQ:
+    """Line DQ (VFI convention) for unit ``direction`` through ``position``."""
+    l_dq = _vector_to_dq(direction)
+    return l_dq + E_ * cross(_vector_to_dq(position), l_dq)
+
+
+def load_scene(path: str, sim: M3_Simulator) -> Scene:
+    """Load a scene from a YAML file into ``sim`` and return a :class:`Scene`.
+
+    See the module docstring for the accepted keys (robots, points, planes,
+    lines, q0). Named object poses are stored on the simulator; the parsed
+    robots and primitives are returned for visualization.
+    """
+    import yaml
+
+    with open(path, "r") as f:
+        data = yaml.safe_load(f) or {}
+
+    sim.stop_simulation()
+
+    robots: List[Tuple[str, M3_SerialManipulatorEDH]] = []
+    for r in data.get("robots", []) or []:
+        name = r["name"]
+        dh = np.asarray(r["dh"], dtype=float)
+        if dh.shape[0] != 5:
+            raise ValueError(
+                f"robot '{name}': the DH matrix must have 5 rows "
+                f"[theta; d; a; alpha; offset]; got shape {dh.shape}"
+            )
+        robot = M3_SerialManipulatorEDH(dh)
+        limits = r.get("limits")
+        if limits is not None:
+            scale = np.pi / 180.0 if limits.get("unit", "deg") == "deg" else 1.0
+            robot.set_lower_q_limit(np.asarray(limits["lower"], dtype=float) * scale)
+            robot.set_upper_q_limit(np.asarray(limits["upper"], dtype=float) * scale)
+        if "base" in r:
+            robot.set_base_frame(_pose_from_translation(r["base"]))
+        else:
+            robot.set_base_frame(DQ([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+        if "effector" in r:
+            robot.set_effector_frame(_pose_from_translation(r["effector"]))
+        else:
+            robot.set_effector_frame(DQ([1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]))
+        sim.set_object_pose(name, robot.get_base_frame())
+        robots.append((name, robot))
+
+    points: List[Tuple[str, float, str]] = []
+    for p in data.get("points", []) or []:
+        name = p["name"]
+        sim.set_object_pose(name, _pose_from_translation(p["pos"]))
+        points.append((name, float(p.get("radius", 0.02)), p.get("color", "b")))
+
+    planes: List[Tuple[str, DQ, str]] = []
+    for p in data.get("planes", []) or []:
+        name = p["name"]
+        n_vec = _unit(p["normal"])
+        p0 = np.asarray(p["position"], dtype=float)
+        r = _rotation_quat_between(np.array([0.0, 0.0, 1.0]), n_vec)
+        sim.set_object_pose(name, _frame_pose(r, p0))
+        planes.append((name, _plane_dq(p0, n_vec), p.get("color", "g")))
+
+    lines: List[Tuple[str, DQ, str]] = []
+    for l in data.get("lines", []) or []:
+        name = l["name"]
+        d_vec = _unit(l["direction"])
+        p0 = np.asarray(l["position"], dtype=float)
+        r = _rotation_quat_between(np.array([0.0, 0.0, 1.0]), d_vec)
+        sim.set_object_pose(name, _frame_pose(r, p0))
+        lines.append((name, _line_dq(p0, d_vec), l.get("color", "r")))
+
+    q0 = None
+    if "q0" in data:
+        q0 = np.asarray(data["q0"], dtype=float)
+        sim.set_configuration_space_positions(q0)
+
+    return Scene(robots=robots, points=points, planes=planes, lines=lines, q0=q0, sim=sim)
+
+
+def _require_dqp():
+    try:
+        import dqrobotics_extensions.pyplot as dqp
+    except ImportError as e:
+        raise ImportError(
+            "M3_PyPlotSimulator requires matplotlib and dqrobotics-pyplot; "
+            "install them with:  python3 -m pip install dqrobotics-pyplot"
+        ) from e
+    return dqp
+
+
+def _draw_robot(ax, scene: Scene, sim: M3_Simulator):
+    dqp = _require_dqp()
+    q = np.asarray(sim.get_configuration_space_positions())
+    for _name, robot in scene.robots:
+        dqp.plot(robot, q=q, ax=ax)
+
+
+def _draw_points(ax, scene: Scene, sim: M3_Simulator):
+    dqp = _require_dqp()
+    for name, radius, color in scene.points:
+        # _plot_sphere expects a pure quaternion at the point's position.
+        p = translation(sim.get_object_pose(name))
+        dqp.plot(p, sphere=True, radius=radius, color=color, ax=ax)
+
+
+def _draw_planes(ax, scene: Scene):
+    dqp = _require_dqp()
+    for _name, pi_dq, color in scene.planes:
+        dqp.plot(pi_dq, plane=True, scale=0.4, color=color, ax=ax)
+
+
+def _draw_lines(ax, scene: Scene):
+    dqp = _require_dqp()
+    for _name, l_dq, color in scene.lines:
+        dqp.plot(l_dq, line=True, scale=0.5, color=color, ax=ax)
+
+
+class M3_PyPlotSimulator(M3_Simulator):
+    """A visualization backend for :class:`M3_Simulator`.
+
+    Loads a YAML scene (see :func:`load_scene`) and draws it with
+    ``dqrobotics_extensions.pyplot`` (matplotlib). It overrides the virtual
+    :meth:`draw_scene` provided by the C++ base (through the pybind11
+    trampoline), so it is a concrete example of subclassing ``M3_Simulator``
+    from Python.
+
+    Example:
+
+        import matplotlib.pyplot as plt
+        from marinholab.papers.tro2022.adaptive_control import M3_PyPlotSimulator
+
+        sim = M3_PyPlotSimulator()
+        sim.load_scene("scene.yaml")
+        plt.figure()
+        plt.axes(projection="3d")
+        sim.draw_scene()
+        plt.show()
+
+    The current matplotlib axes is used (the dqrobotics_extensions.pyplot
+    convention); a 3d axes is created on demand if none is current.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._scene: Optional[Scene] = None
+
+    def load_scene(self, path: str) -> Scene:
+        """Load a YAML scene into this simulator (see :func:`load_scene`)."""
+        self._scene = load_scene(path, self)
+        return self._scene
+
+    def draw_scene(self):
+        """Draw the loaded scene onto the current (3d) matplotlib axes."""
+        if self._scene is None:
+            raise RuntimeError("no scene loaded; call load_scene(path) first")
+        from matplotlib import pyplot as plt
+
+        ax = plt.gca()
+        if not hasattr(ax, "proj3d"):
+            ax = plt.axes(projection="3d")
+        _draw_robot(ax, self._scene, self)
+        _draw_points(ax, self._scene, self)
+        _draw_planes(ax, self._scene)
+        _draw_lines(ax, self._scene)

--- a/marinholab/papers/tro2022/adaptive_control/scene.py
+++ b/marinholab/papers/tro2022/adaptive_control/scene.py
@@ -241,6 +241,48 @@ def _draw_lines(ax, scene: Scene):
         dqp.plot(l_dq, line=True, scale=0.5, color=color, ax=ax)
 
 
+def _as_configuration_sequence(q) -> List[np.ndarray]:
+    """Normalize ``q`` into a list of configuration arrays.
+
+    Accepts a single 1-D configuration, a list/tuple of configurations, or a
+    2-D array of shape ``(n, dim)`` (one configuration per row). A list/tuple
+    of scalars is treated as one configuration.
+    """
+    if isinstance(q, (list, tuple)):
+        # A list of scalars is a single configuration; a list of sequences is
+        # a sequence of configurations.
+        if q and np.asarray(q[0]).ndim == 0:
+            return [np.asarray(q, dtype=float)]
+        return [np.asarray(c, dtype=float) for c in q]
+    arr = np.asarray(q, dtype=float)
+    if arr.ndim == 1:
+        return [arr]
+    if arr.ndim == 2:
+        return [arr[i] for i in range(arr.shape[0])]
+    raise ValueError(
+        f"expected a 1-D configuration or a 2-D array of shape (n, dim), got "
+        f"an array of shape {arr.shape}"
+    )
+
+
+def _animation_writer(path: str, fps: float):
+    """Pick a matplotlib ``MovieWriter`` for ``path`` (GIF, or ffmpeg-based)."""
+    import os
+    import shutil
+
+    import matplotlib.animation as manim
+
+    ext = os.path.splitext(path)[1].lower()
+    if ext == ".gif":
+        return manim.PillowWriter(fps=fps)
+    if shutil.which("ffmpeg") is None:
+        raise RuntimeError(
+            f"writing '{path}' needs ffmpeg, which is not on PATH; use a "
+            f".gif path instead (always available)"
+        )
+    return manim.FFMpegWriter(fps=fps)
+
+
 class M3_PyPlotSimulator(M3_Simulator):
     """A visualization backend for :class:`M3_Simulator`.
 
@@ -250,7 +292,7 @@ class M3_PyPlotSimulator(M3_Simulator):
     trampoline), so it is a concrete example of subclassing ``M3_Simulator``
     from Python.
 
-    Example:
+    Example (single image):
 
         import matplotlib.pyplot as plt
         from marinholab.papers.tro2022.adaptive_control import M3_PyPlotSimulator
@@ -262,8 +304,18 @@ class M3_PyPlotSimulator(M3_Simulator):
         sim.draw_scene()
         plt.show()
 
-    The current matplotlib axes is used (the dqrobotics_extensions.pyplot
-    convention); a 3d axes is created on demand if none is current.
+    ``draw_scene`` is idempotent: the static scene elements (points, planes,
+    lines) are drawn once per axes and only the robot is redrawn afterwards,
+    so repeated calls do not create new axes or accumulate artists. That is
+    also what makes :meth:`animation` cheap.
+
+    Example (matplotlib animation):
+
+        sim.load_scene("scene.yaml")
+        qs = [q0, q1, ..., qn]             # configurations to animate
+        anim = sim.animation(qs)                    # interactive backends
+        # or headless (no display needed):
+        anim = sim.animation(qs, save_as="traj.gif")
     """
 
     def __init__(self):
@@ -275,16 +327,105 @@ class M3_PyPlotSimulator(M3_Simulator):
         self._scene = load_scene(path, self)
         return self._scene
 
-    def draw_scene(self):
-        """Draw the loaded scene onto the current (3d) matplotlib axes."""
+    def draw_scene(self, axes=None):
+        """Draw the loaded scene onto a (3d) matplotlib axes.
+
+        If ``axes`` is given (an ``Axes3D``) it is used directly; otherwise the
+        current axes is used and a new 3d axes is created if the current one is
+        not 3d. Calling this repeatedly on the same axes only redraws the
+        robot (the static scene elements are kept), so it can be used as the
+        per-frame update of a matplotlib animation.
+        """
         if self._scene is None:
             raise RuntimeError("no scene loaded; call load_scene(path) first")
         from matplotlib import pyplot as plt
 
-        ax = plt.gca()
-        if not hasattr(ax, "proj3d"):
-            ax = plt.axes(projection="3d")
-        _draw_robot(ax, self._scene, self)
-        _draw_points(ax, self._scene, self)
-        _draw_planes(ax, self._scene)
-        _draw_lines(ax, self._scene)
+        if axes is None:
+            from mpl_toolkits.mplot3d.axes3d import Axes3D
+
+            axes = plt.gca()
+            if not isinstance(axes, Axes3D):
+                axes = plt.axes(projection="3d")
+        self._draw_scene(axes)
+
+    def _draw_scene(self, axes):
+        static_drawn = getattr(axes, "_tro2022_static_drawn", False)
+        scene_id = getattr(axes, "_tro2022_scene_id", None)
+        if static_drawn and scene_id == id(self._scene):
+            self._redraw_robot(axes)
+        else:
+            self._clear_data_artists(axes)          # stale static/robot artists
+            _draw_points(axes, self._scene, self)
+            _draw_planes(axes, self._scene)
+            _draw_lines(axes, self._scene)
+            axes._tro2022_static_drawn = True
+            axes._tro2022_scene_id = id(self._scene)
+            self._redraw_robot(axes)
+
+    def _redraw_robot(self, axes):
+        """Clear the previous robot artists and redraw the robot (tagged)."""
+        self._clear_data_artists(axes, robot_only=True)
+        before = {id(o) for o in axes.get_children()}
+        _draw_robot(axes, self._scene, self)
+        for o in axes.get_children():               # tag the new (robot) artists
+            if id(o) not in before:
+                o._tro2022_robot = True
+
+    def _clear_data_artists(self, axes, robot_only: bool = False):
+        """Remove the artists drawn by ``_draw_robot`` (or all data artists)."""
+        from matplotlib.collections import LineCollection, PolyCollection
+        from matplotlib.lines import Line2D
+
+        for o in list(axes.get_children()):
+            # Line2D also covers 3d lines (Line3D); LineCollection covers the
+            # quivers (Line3DCollection); PolyCollection covers plot_surface.
+            if isinstance(o, (Line2D, LineCollection, PolyCollection)) and (
+                not robot_only or getattr(o, "_tro2022_robot", False)
+            ):
+                o.remove()
+
+    def animation(self, q, frames_per_step: int = 1, save_as: Optional[str] = None,
+                  **anim_kwargs):
+        """Animate robot configurations with matplotlib's ``FuncAnimation``.
+
+        ``q`` is a single 1-D configuration, a list/tuple of configurations, or
+        a 2-D array of shape ``(n, dim)`` (one configuration per row);
+        ``frames_per_step`` repeats each configuration for that many animation
+        frames (default 1).
+
+        The static scene is drawn once and each frame only redraws the robot
+        (see :meth:`draw_scene`), which is far cheaper than redrawing the whole
+        scene per frame and keeps the artist count constant.
+
+        If ``save_as`` is given (e.g. ``"traj.gif"``) the animation is written
+        to that file; GIF always works, other formats need ffmpeg (e.g.
+        ``"traj.mp4"``). Extra ``anim_kwargs`` are forwarded to
+        ``FuncAnimation`` (``interval``, ``blit`` (default False), ``fps`` when
+        saving, ...). Returns the ``FuncAnimation`` object.
+        """
+        if self._scene is None:
+            raise RuntimeError("no scene loaded; call load_scene(path) first")
+        import matplotlib.pyplot as plt
+        import matplotlib.animation as manim
+
+        configs = _as_configuration_sequence(q)
+        fpp = max(1, int(frames_per_step))
+
+        fig = plt.figure()
+        axes = plt.axes(projection="3d")
+        self.draw_scene(axes)                       # static scene + first robot
+
+        def _update(frame):
+            i = (frame // fpp) % len(configs)
+            self.set_configuration_space_positions(configs[i])
+            self._redraw_robot(axes)
+            return []
+
+        anim_kwargs.setdefault("blit", False)
+        anim_kwargs.setdefault("interval", 100)
+        anim = manim.FuncAnimation(fig, _update, frames=len(configs) * fpp,
+                                   **anim_kwargs)
+        if save_as is not None:
+            fps = anim_kwargs.get("fps", 1000.0 / anim_kwargs["interval"])
+            anim.save(save_as, writer=_animation_writer(save_as, fps))
+        return anim

--- a/marinholab/papers/tro2022/adaptive_control/scene.py
+++ b/marinholab/papers/tro2022/adaptive_control/scene.py
@@ -83,26 +83,19 @@ class Scene:
     sim: M3_Simulator
 
 
-def _vector_to_dq(v) -> DQ:
-    """Build a pure-vector DQ from a 3-vector ``v = [vx, vy, vz]``."""
-    v = np.asarray(v, dtype=float)
-    if v.shape != (3,):
-        raise ValueError(f"expected a 3-vector [vx, vy, vz], got {v!r}")
-    return v[0] * i_ + v[1] * j_ + v[2] * k_
-
-
 def _unit(v):
+    """The unit vector of a non-zero 3-vector ``v`` (via DQ.normalize)."""
     v = np.asarray(v, dtype=float)
-    n = np.linalg.norm(v)
-    if n < 1e-12:
+    if np.linalg.norm(v) < 1e-12:
         raise ValueError("expected a non-zero vector, got a zero vector")
-    return v / n
+    # DQ() on a 3-vector is a pure quaternion; normalize() returns the
+    # normalized DQ (a pure unit quaternion), so the vector part is q[1:4].
+    return np.array(DQ(v).normalize().q[1:4])
 
 
 def _pose_from_translation(t) -> DQ:
     """A DQ pose from a translation ``t`` and the identity rotation."""
-    t_dq = _vector_to_dq(t)
-    return DQ([1.0]) + 0.5 * E_ * t_dq * DQ([1.0])
+    return DQ([1.0]) + 0.5 * E_ * DQ(np.asarray(t, dtype=float)) * DQ([1.0])
 
 
 def _rotation_quat_between(a, b) -> DQ:
@@ -125,19 +118,19 @@ def _rotation_quat_between(a, b) -> DQ:
 
 def _frame_pose(r: DQ, t) -> DQ:
     """A frame pose: rotation ``r`` (unit quaternion DQ) + translation ``t``."""
-    return r + 0.5 * E_ * _vector_to_dq(t) * r
+    return r + 0.5 * E_ * DQ(np.asarray(t, dtype=float)) * r
 
 
 def _plane_dq(position, normal) -> DQ:
     """Plane DQ (VFI convention) for unit ``normal`` through ``position``."""
-    n_dq = _vector_to_dq(normal)
-    return n_dq + E_ * dot(_vector_to_dq(position), n_dq)
+    n_dq = DQ(np.asarray(normal, dtype=float))
+    return n_dq + E_ * dot(DQ(np.asarray(position, dtype=float)), n_dq)
 
 
 def _line_dq(position, direction) -> DQ:
     """Line DQ (VFI convention) for unit ``direction`` through ``position``."""
-    l_dq = _vector_to_dq(direction)
-    return l_dq + E_ * cross(_vector_to_dq(position), l_dq)
+    l_dq = DQ(np.asarray(direction, dtype=float))
+    return l_dq + E_ * cross(DQ(np.asarray(position, dtype=float)), l_dq)
 
 
 def load_scene(path: str, sim: M3_Simulator) -> Scene:

--- a/marinholab/papers/tro2022/adaptive_control/scene.py
+++ b/marinholab/papers/tro2022/adaptive_control/scene.py
@@ -397,11 +397,13 @@ class M3_PyPlotSimulator(M3_Simulator):
         (see :meth:`draw_scene`), which is far cheaper than redrawing the whole
         scene per frame and keeps the artist count constant.
 
-        If ``save_as`` is given (e.g. ``"traj.gif"``) the animation is written
-        to that file; GIF always works, other formats need ffmpeg (e.g.
-        ``"traj.mp4"``). Extra ``anim_kwargs`` are forwarded to
-        ``FuncAnimation`` (``interval``, ``blit`` (default False), ``fps`` when
-        saving, ...). Returns the ``FuncAnimation`` object.
+        If ``save_as`` is given (e.g. ``"traj.gif"`` or ``"traj.mp4"``) the
+        animation is written to that file: GIF always works (PillowWriter),
+        other containers use ffmpeg when it is on PATH (FFMpegWriter). ``fps``
+        (used only when saving; defaults to ``1000 / interval``) and the
+        remaining ``anim_kwargs`` are forwarded to ``FuncAnimation``
+        (``interval``, ``blit`` (default False), ...). Returns the
+        ``FuncAnimation`` object.
         """
         if self._scene is None:
             raise RuntimeError("no scene loaded; call load_scene(path) first")
@@ -410,6 +412,7 @@ class M3_PyPlotSimulator(M3_Simulator):
 
         configs = _as_configuration_sequence(q)
         fpp = max(1, int(frames_per_step))
+        fps = anim_kwargs.pop("fps", None)        # save()-only keyword
 
         fig = plt.figure()
         axes = plt.axes(projection="3d")
@@ -426,6 +429,7 @@ class M3_PyPlotSimulator(M3_Simulator):
         anim = manim.FuncAnimation(fig, _update, frames=len(configs) * fpp,
                                    **anim_kwargs)
         if save_as is not None:
-            fps = anim_kwargs.get("fps", 1000.0 / anim_kwargs["interval"])
+            if fps is None:
+                fps = 1000.0 / anim_kwargs["interval"]
             anim.save(save_as, writer=_animation_writer(save_as, fps))
         return anim

--- a/marinholab/papers/tro2022/adaptive_control/scene.py
+++ b/marinholab/papers/tro2022/adaptive_control/scene.py
@@ -117,12 +117,12 @@ def _frame_pose(r: DQ, t: DQ) -> DQ:
     return r + 0.5 * E_ * t * r
 
 
-def _plane_dq(position: DQ, normal: DQ) -> DQ:
+def plane(position: DQ, normal: DQ) -> DQ:
     """Plane DQ (VFI convention) for unit ``normal`` through ``position``."""
     return normal + E_ * dot(position, normal)
 
 
-def _line_dq(position: DQ, direction: DQ) -> DQ:
+def line(position: DQ, direction: DQ) -> DQ:
     """Line DQ (VFI convention) for unit ``direction`` through ``position``."""
     return direction + E_ * cross(position, direction)
 
@@ -180,7 +180,7 @@ def load_scene(path: str, sim: M3_Simulator) -> Scene:
         p0 = DQ(np.asarray(p["position"], dtype=float))
         r = _rotation_quat_between(DQ([0.0, 0.0, 1.0]), normal)
         sim.set_object_pose(name, _frame_pose(r, p0))
-        planes.append((name, _plane_dq(p0, normal), p.get("color", "g")))
+        planes.append((name, plane(p0, normal), p.get("color", "g")))
 
     lines: List[Tuple[str, DQ, str]] = []
     for l in data.get("lines", []) or []:
@@ -189,7 +189,7 @@ def load_scene(path: str, sim: M3_Simulator) -> Scene:
         p0 = DQ(np.asarray(l["position"], dtype=float))
         r = _rotation_quat_between(DQ([0.0, 0.0, 1.0]), d_vec)
         sim.set_object_pose(name, _frame_pose(r, p0))
-        lines.append((name, _line_dq(p0, d_vec), l.get("color", "r")))
+        lines.append((name, line(p0, d_vec), l.get("color", "r")))
 
     q0 = None
     if "q0" in data:

--- a/marinholab/papers/tro2022/adaptive_control/scene.py
+++ b/marinholab/papers/tro2022/adaptive_control/scene.py
@@ -83,14 +83,12 @@ class Scene:
     sim: M3_Simulator
 
 
-def _unit(v):
-    """The unit vector of a non-zero 3-vector ``v`` (via DQ.normalize)."""
-    v = np.asarray(v, dtype=float)
-    if np.linalg.norm(v) < 1e-12:
+def _unit(v) -> DQ:
+    """Pure unit quaternion DQ of a non-zero 3-vector ``v`` (via DQ.normalize)."""
+    v_dq = DQ(np.asarray(v, dtype=float))
+    if float(norm(v_dq).q[0]) < 1e-12:
         raise ValueError("expected a non-zero vector, got a zero vector")
-    # DQ() on a 3-vector is a pure quaternion; normalize() returns the
-    # normalized DQ (a pure unit quaternion), so the vector part is q[1:4].
-    return np.array(DQ(v).normalize().q[1:4])
+    return v_dq.normalize()
 
 
 def _pose_from_translation(t) -> DQ:
@@ -98,39 +96,35 @@ def _pose_from_translation(t) -> DQ:
     return DQ([1.0]) + 0.5 * E_ * DQ(np.asarray(t, dtype=float)) * DQ([1.0])
 
 
-def _rotation_quat_between(a, b) -> DQ:
+def _rotation_quat_between(a: DQ, b: DQ) -> DQ:
     """Unit quaternion (as a DQ) rotating unit vector ``a`` onto unit vector ``b``."""
-    a = _unit(a)
-    b = _unit(b)
-    cosang = float(np.clip(np.dot(a, b), -1.0, 1.0))
+    cosang = float(np.clip(dot(a, b).q[0], -1.0, 1.0))
     if cosang > 1.0 - 1e-12:            # same direction: identity
         return DQ([1.0, 0.0, 0.0, 0.0])
     if cosang < -1.0 + 1e-12:           # opposite: 180 deg about an orthogonal axis
-        tmp = np.array([1.0, 0.0, 0.0]) if abs(a[0]) < 0.9 else np.array([0.0, 1.0, 0.0])
-        v = np.cross(a, tmp)
-        return DQ([0.0, v[0], v[1], v[2]])
-    v = np.cross(a, b)
-    vhat = v / np.linalg.norm(v)
+        tmp = DQ([1.0, 0.0, 0.0]) if abs(a.q[1]) < 0.9 else DQ([0.0, 1.0, 0.0])
+        # cross(a, tmp) is a pure quaternion; normalized, it is the 180-degree
+        # (half-angle 90-degree) quaternion about that axis.
+        return cross(a, tmp).normalize()
+    vhat = cross(a, b).normalize()      # pure unit quaternion = the rotation axis
     half_cos = float(np.sqrt((1.0 + cosang) / 2.0))
     half_sin = float(np.sqrt((1.0 - cosang) / 2.0))
-    return DQ([half_cos, vhat[0] * half_sin, vhat[1] * half_sin, vhat[2] * half_sin])
+    return half_cos + half_sin * vhat
 
 
-def _frame_pose(r: DQ, t) -> DQ:
+def _frame_pose(r: DQ, t: DQ) -> DQ:
     """A frame pose: rotation ``r`` (unit quaternion DQ) + translation ``t``."""
-    return r + 0.5 * E_ * DQ(np.asarray(t, dtype=float)) * r
+    return r + 0.5 * E_ * t * r
 
 
-def _plane_dq(position, normal) -> DQ:
+def _plane_dq(position: DQ, normal: DQ) -> DQ:
     """Plane DQ (VFI convention) for unit ``normal`` through ``position``."""
-    n_dq = DQ(np.asarray(normal, dtype=float))
-    return n_dq + E_ * dot(DQ(np.asarray(position, dtype=float)), n_dq)
+    return normal + E_ * dot(position, normal)
 
 
-def _line_dq(position, direction) -> DQ:
+def _line_dq(position: DQ, direction: DQ) -> DQ:
     """Line DQ (VFI convention) for unit ``direction`` through ``position``."""
-    l_dq = DQ(np.asarray(direction, dtype=float))
-    return l_dq + E_ * cross(DQ(np.asarray(position, dtype=float)), l_dq)
+    return direction + E_ * cross(position, direction)
 
 
 def load_scene(path: str, sim: M3_Simulator) -> Scene:
@@ -182,18 +176,18 @@ def load_scene(path: str, sim: M3_Simulator) -> Scene:
     planes: List[Tuple[str, DQ, str]] = []
     for p in data.get("planes", []) or []:
         name = p["name"]
-        n_vec = _unit(p["normal"])
-        p0 = np.asarray(p["position"], dtype=float)
-        r = _rotation_quat_between(np.array([0.0, 0.0, 1.0]), n_vec)
+        normal = _unit(p["normal"])
+        p0 = DQ(np.asarray(p["position"], dtype=float))
+        r = _rotation_quat_between(DQ([0.0, 0.0, 1.0]), normal)
         sim.set_object_pose(name, _frame_pose(r, p0))
-        planes.append((name, _plane_dq(p0, n_vec), p.get("color", "g")))
+        planes.append((name, _plane_dq(p0, normal), p.get("color", "g")))
 
     lines: List[Tuple[str, DQ, str]] = []
     for l in data.get("lines", []) or []:
         name = l["name"]
         d_vec = _unit(l["direction"])
-        p0 = np.asarray(l["position"], dtype=float)
-        r = _rotation_quat_between(np.array([0.0, 0.0, 1.0]), d_vec)
+        p0 = DQ(np.asarray(l["position"], dtype=float))
+        r = _rotation_quat_between(DQ([0.0, 0.0, 1.0]), d_vec)
         sim.set_object_pose(name, _frame_pose(r, p0))
         lines.append((name, _line_dq(p0, d_vec), l.get("color", "r")))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,17 @@ description="A Python implementation of an example of 'Adaptive Constrained Kine
 readme = "README.md"
 requires-python = ">= 3.9"
 
+# The core package (adaptive control + headless M3_SimulatorDummy) only needs
+# dqrobotics. The optional visualization backend (M3_PyPlotSimulator, which
+# loads a YAML scene and draws it with dqrobotics-pyplot) is provided as the
+# "viz" extra and imports its dependencies lazily, so the base package can be
+# installed and used headless without them (python3 -m pip install .[viz]).
+[project.optional-dependencies]
+viz = [
+    'dqrobotics-pyplot',
+    'PyYAML',
+]
+
 # https://pypi.org/project/setuptools-git-versioning/
 [tool.setuptools-git-versioning]
 enabled = true

--- a/scenes/example.yaml
+++ b/scenes/example.yaml
@@ -1,0 +1,62 @@
+# Example scene for the TRO2022 adaptive-control example.
+# Mirrors the nominal TRO2022 reference scene used by M3_SimulatorDummy:
+# a 6-DoF VS050 robot, a 40 cm cube workspace (4 walls), 2 vertical tubes and
+# the two task targets (xd0 safe approach, xd1 unreachable target).
+#
+# Conventions (match M3_VFI):
+#   * a plane is given by a point (`position`) and its (unit) `normal`;
+#   * a line  is given by a point (`position`) and its (unit) `direction`;
+#   * the initial configuration `q0` is in radians.
+
+robots:
+  - name: vs050
+    dh:
+      # [theta; d; a; alpha; offset]   (radians)
+      - [-1.5707963,  1.5707963, -1.5707963, 0.0,  1.5707963, 0.0]
+      - [ 0.345,      0.0,        0.0,       0.255, 0.0,      0.07]
+      - [ 0.0,        0.25,       0.01,      0.0,   0.0,      0.0]
+      - [ 1.5707963,  0.0,       -1.5707963, 1.5707963, 1.5707963, 0.0]
+      - [ 0.0,        0.0,        0.0,       0.0,   0.0,      0.0]
+    limits:
+      lower: [-170., -100., -60., -265., -119., -355.]
+      upper: [ 170.,  100., 124.,  265.,  89.9, 355.]
+      unit: deg
+
+# Four walls of the 40 cm cube (half-size 0.2 in x and y; open in z).
+# The normals point inward (FORBIDDEN_ZONE keeps the robot inside the box).
+planes:
+  - name: wall_1      # x = +0.2, inward normal -i
+    position: [ 0.2, 0.0, 0.0]
+    normal:   [-1.0, 0.0, 0.0]
+  - name: wall_2      # x = -0.2, inward normal +i
+    position: [-0.2, 0.0, 0.0]
+    normal:   [ 1.0, 0.0, 0.0]
+  - name: wall_3      # y = +0.2, inward normal -j
+    position: [0.0,  0.2, 0.0]
+    normal:   [ 0.0, -1.0, 0.0]
+  - name: wall_4      # y = -0.2, inward normal +j
+    position: [0.0, -0.2, 0.0]
+    normal:   [ 0.0,  1.0, 0.0]
+
+# Two vertical tubes (lines) along z, at y = +/- 0.12.
+lines:
+  - name: tube_1
+    position: [0.0,  0.12, 0.0]
+    direction: [0.0, 0.0, 1.0]
+  - name: tube_2
+    position: [0.0, -0.12, 0.0]
+    direction: [0.0, 0.0, 1.0]
+
+# Task targets.
+points:
+  - name: xd0          # safe approach pose (the world origin)
+    pos:    [0.0, 0.0, 0.0]
+    radius: 0.03
+    color:  g
+  - name: xd1          # unreachable target (z = 0.55)
+    pos:    [0.0, 0.0, 0.55]
+    radius: 0.03
+    color:  r
+
+# Initial robot configuration (radians), a folded posture inside the box.
+q0: [2.32698, -0.427311, 0.681903, 1.4088, -0.759787, 0.879927]

--- a/src/adaptive_control_example_py.cpp
+++ b/src/adaptive_control_example_py.cpp
@@ -7,6 +7,7 @@
 #include "marinholab/papers/tro2022/adaptive_control/M3_AdaptiveController.h"
 #include "marinholab/papers/tro2022/adaptive_control/M3_VFI.h"
 #include "marinholab/papers/tro2022/adaptive_control/M3_SerialManipulatorEDH.h"
+#include "marinholab/papers/tro2022/adaptive_control/M3_Simulator.h"
 #include "marinholab/papers/tro2022/adaptive_control/M3_SimulatorDummy.h"
 #include "marinholab/papers/tro2022/adaptive_control/M3_MeasurementSpace.h"
 
@@ -15,6 +16,26 @@
 
 namespace py = pybind11;
 using namespace DQ_robotics;
+
+// Trampoline so M3_Simulator can be subclassed from Python: a Python subclass
+// can override draw_scene (the visualization hook). The base class keeps a
+// no-op default, so this falls back to the (headless) no-op when a Python
+// override is absent. It inherits py::trampoline_self_life_support as required
+// when the class is exposed with py::smart_holder (see the M3_Simulator
+// binding below).
+class PyM3_Simulator : public M3_Simulator, public py::trampoline_self_life_support
+{
+public:
+    using M3_Simulator::M3_Simulator; // Inherit the constructors
+    void draw_scene() override
+    {
+        PYBIND11_OVERRIDE(
+            void,         // Return type
+            M3_Simulator, // Parent class
+            draw_scene    // Name of the function in C++ (must match the Python name)
+        );
+    }
+};
 
 PYBIND11_MODULE(_core, m) {
 
@@ -110,7 +131,7 @@ PYBIND11_MODULE(_core, m) {
                  const std::string&,
                  const std::string&,
                  const M3_Primitive&,
-                 const std::shared_ptr<M3_SimulatorDummy>&,
+                 const std::shared_ptr<M3_Simulator>&,
                  const double&,
                  const M3_VFI_Direction&,
                  const int&,
@@ -318,20 +339,56 @@ PYBIND11_MODULE(_core, m) {
     M3_SerialManipulatorEDH.def("get_dim_configuration_space",&M3_SerialManipulatorEDH::get_dim_configuration_space,"");
 
 
+    /// "M3_Simulator.h"
+
+    //class M3_Simulator (base; exposed with a trampoline so it can be
+    // subclassed from Python, e.g. a pyplot-based visualization backend).
+    // smart_holder (py::classh) is used because M3_Simulator is subclassed from
+    // Python and also converted to std::shared_ptr<M3_Simulator> in C++ (e.g.
+    // M3_VFI): per the pybind11 docs, smart_holder avoids inheritance slicing
+    // for such trampoline classes.
+    py::classh<M3_Simulator, PyM3_Simulator>(
+            m, "M3_Simulator",
+            "Base class of a robot-scene simulator. Holds a named set of scene "
+            "object poses (DQ), the robot configuration (joint-space) and the "
+            "simulation start/stop state. Exposed with a trampoline so it can be "
+            "subclassed from Python by overriding draw_scene.")
+            .def(py::init<>())
+            .def("draw_scene", &M3_Simulator::draw_scene,
+                 "Draw the scene (robots, obstacles, targets). Headless default does "
+                 "nothing; a visualization backend overrides this.")
+            .def("get_object_pose", &M3_Simulator::get_object_pose,
+                 "Return the pose of the named object.", py::arg("object_name"))
+            .def("get_object_pose_or_default", &M3_Simulator::get_object_pose_or_default,
+                 "Return the pose of the named object, or default_pose if absent.",
+                 py::arg("object_name"), py::arg("default_pose"))
+            .def("set_object_pose", &M3_Simulator::set_object_pose,
+                 "Set (or create) the pose of the named object.",
+                 py::arg("object_name"), py::arg("pose"))
+            .def("has_object", &M3_Simulator::has_object,
+                 "Whether an object with the given name exists in the scene.",
+                 py::arg("object_name"))
+            .def("get_object_names", &M3_Simulator::get_object_names,
+                 "The names of all objects currently in the scene.")
+            .def("get_configuration_space_positions",
+                 &M3_Simulator::get_configuration_space_positions,
+                 "The current robot configuration (joint-space).")
+            .def("set_configuration_space_positions",
+                 &M3_Simulator::set_configuration_space_positions,
+                 "Set the robot configuration (joint-space).", py::arg("q"))
+            .def("start_simulation", &M3_Simulator::start_simulation)
+            .def("stop_simulation", &M3_Simulator::stop_simulation)
+            .def("is_running", &M3_Simulator::is_running);
+
     /// "M3_SimulatorDummy.h"
 
-    //class M3_SimulatorDummy
-    py::class_<M3_SimulatorDummy, std::shared_ptr<M3_SimulatorDummy>>(m, "M3_SimulatorDummy")
+    //class M3_SimulatorDummy : public M3_Simulator
+    // Same smart_holder as its base so the whole hierarchy converts cleanly to
+    // std::shared_ptr<M3_Simulator> (e.g. for M3_VFI).
+    py::classh<M3_SimulatorDummy, M3_Simulator>(
+            m, "M3_SimulatorDummy",
+            "In-memory, headless M3_Simulator backend (no real simulator).")
             .def(py::init<>())
-            .def("get_object_pose", &M3_SimulatorDummy::get_object_pose, "", py::arg("object_name"))
-            .def("set_object_pose", &M3_SimulatorDummy::set_object_pose, "", py::arg("object_name"), py::arg("pose"))
-            .def("has_object", &M3_SimulatorDummy::has_object, "", py::arg("object_name"))
-            .def("get_object_names", &M3_SimulatorDummy::get_object_names)
-            .def("get_configuration_space_positions", &M3_SimulatorDummy::get_configuration_space_positions)
-            .def("set_configuration_space_positions", &M3_SimulatorDummy::set_configuration_space_positions, "", py::arg("q"))
-            .def("start_simulation", &M3_SimulatorDummy::start_simulation)
-            .def("stop_simulation", &M3_SimulatorDummy::stop_simulation)
-            .def("is_running", &M3_SimulatorDummy::is_running)
             .def("load_reference_scene", &M3_SimulatorDummy::load_reference_scene)
             .def_static("vs050_raw_kinematics", &M3_SimulatorDummy::vs050_raw_kinematics,
                          "Return the VS050 kinematics of the TRO2022 example (ideal base/effector).");

--- a/src/example/M3_Simulator.cpp
+++ b/src/example/M3_Simulator.cpp
@@ -1,0 +1,94 @@
+/**
+(C) Copyright 2020-2026 Murilo Marques Marinho (www.murilomarinho.info)
+
+This file is part of adaptive_control_example.
+
+    DQ Robotics is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Lesser General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    adaptive_control_example is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License
+    along with adaptive_control_example.  If not, see <http://www.gnu.org/licenses/>.
+
+Author:
+    Murilo M. Marinho (murilomarinho@ieee.org)
+
+Contributors (aside from author):
+    None
+*/
+
+#include "marinholab/papers/tro2022/adaptive_control/M3_Simulator.h"
+
+#include <stdexcept>
+
+void M3_Simulator::draw_scene()
+{
+    // Headless default: nothing to draw. Backends (e.g. the Python-side
+    // M3_PyPlotSimulator) override this to render the scene.
+}
+
+DQ M3_Simulator::get_object_pose(const std::string& object_name) const
+{
+    const auto it = object_poses_.find(object_name);
+    if(it == object_poses_.end())
+        throw std::runtime_error("M3_Simulator: object \"" + object_name + "\" not found in the scene.");
+    return it->second;
+}
+
+DQ M3_Simulator::get_object_pose_or_default(const std::string& object_name, const DQ& default_pose) const
+{
+    const auto it = object_poses_.find(object_name);
+    if(it == object_poses_.end())
+        return default_pose;
+    return it->second;
+}
+
+void M3_Simulator::set_object_pose(const std::string& object_name, const DQ& pose)
+{
+    object_poses_[object_name] = pose;
+}
+
+bool M3_Simulator::has_object(const std::string& object_name) const
+{
+    return object_poses_.find(object_name) != object_poses_.end();
+}
+
+std::vector<std::string> M3_Simulator::get_object_names() const
+{
+    std::vector<std::string> names;
+    names.reserve(object_poses_.size());
+    for(const auto& kv : object_poses_)
+        names.push_back(kv.first);
+    return names;
+}
+
+const VectorXd& M3_Simulator::get_configuration_space_positions() const
+{
+    return q_;
+}
+
+void M3_Simulator::set_configuration_space_positions(const VectorXd& q)
+{
+    q_ = q;
+}
+
+void M3_Simulator::start_simulation()
+{
+    running_ = true;
+}
+
+void M3_Simulator::stop_simulation()
+{
+    running_ = false;
+}
+
+bool M3_Simulator::is_running() const
+{
+    return running_;
+}

--- a/src/example/M3_SimulatorDummy.cpp
+++ b/src/example/M3_SimulatorDummy.cpp
@@ -36,58 +36,6 @@ Contributors (aside from author):
 #include <cmath>
 #include <stdexcept>
 
-DQ M3_SimulatorDummy::get_object_pose(const std::string& object_name) const
-{
-    const auto it = object_poses_.find(object_name);
-    if(it == object_poses_.end())
-        throw std::runtime_error("M3_SimulatorDummy: object \"" + object_name + "\" not found in the scene.");
-    return it->second;
-}
-
-void M3_SimulatorDummy::set_object_pose(const std::string& object_name, const DQ& pose)
-{
-    object_poses_[object_name] = pose;
-}
-
-bool M3_SimulatorDummy::has_object(const std::string& object_name) const
-{
-    return object_poses_.find(object_name) != object_poses_.end();
-}
-
-std::vector<std::string> M3_SimulatorDummy::get_object_names() const
-{
-    std::vector<std::string> names;
-    names.reserve(object_poses_.size());
-    for(const auto& kv : object_poses_)
-        names.push_back(kv.first);
-    return names;
-}
-
-const VectorXd& M3_SimulatorDummy::get_configuration_space_positions() const
-{
-    return q_;
-}
-
-void M3_SimulatorDummy::set_configuration_space_positions(const VectorXd& q)
-{
-    q_ = q;
-}
-
-void M3_SimulatorDummy::start_simulation()
-{
-    running_ = true;
-}
-
-void M3_SimulatorDummy::stop_simulation()
-{
-    running_ = false;
-}
-
-bool M3_SimulatorDummy::is_running() const
-{
-    return running_;
-}
-
 void M3_SimulatorDummy::load_reference_scene()
 {
     // The poses below are built with the dual-quaternion algebra written

--- a/src/example/M3_VFI.cpp
+++ b/src/example/M3_VFI.cpp
@@ -39,7 +39,7 @@ Contributors (aside from author):
 M3_VFI::M3_VFI(const std::string &workspace_entity_name,
                const std::string& robot_entity_name,
                const M3_Primitive &type,
-               const std::shared_ptr<M3_SimulatorDummy> &vi,
+               const std::shared_ptr<M3_Simulator> &vi,
                const double &safe_distance,
                const M3_VFI_Direction &vfi_direction,
                const int &joint_index,


### PR DESCRIPTION

## Summary

Refactors the headless simulator into a polymorphic base class (`M3_Simulator`) that `M3_SimulatorDummy` now derives from, exposes it through a **pybind11 trampoline** so it can be subclassed from Python, and ships a **`dqrobotics-pyplot` visualization backend** (`M3_PyPlotSimulator`) that loads a scene from **YAML** and draws it.

Stacked on the open headless-simulator work (this PR targets `fix-build-pollution-copyright`, the current head of #10/#11).

## What changed

**C++ — polymorphic base**
- New `M3_Simulator` base: named object poses (DQ), robot configuration, simulation start/stop bookkeeping, and a virtual `draw_scene()` with a headless no-op default.
- `M3_SimulatorDummy` now only carries the TRO2022 reference scene and the VS050 kinematics; the common methods moved to the base (`M3_Simulator.cpp`, added to CMake).
- `M3_VFI` now holds/accepts `std::shared_ptr<M3_Simulator>`, so the adaptive controller works with **any** backend (the headless dummy or a visualizing Python subclass).

**pybind11 — trampoline + holder**
- `PyM3_Simulator` trampoline (inherits `py::trampoline_self_life_support`) with `py::classh` (**smart_holder**). Per the pybind11 docs, smart_holder is required for a trampoline class that is subclassed from Python *and* converted to `std::shared_ptr<T>` in C++ — it avoids inheritance slicing so a Python override is still dispatched once the object is held by C++ (e.g. inside `M3_VFI`).
- `M3_SimulatorDummy` is bound with `M3_Simulator` as its base (same holder), so `issubclass(M3_SimulatorDummy, M3_Simulator)` is `True`.

**Python — visualization + scene loader**
- `scene.py`: `load_scene(path, sim)` loads a YAML scene (VS050 robot + walls as planes + tubes as lines + target points) into an `M3_Simulator`; `M3_PyPlotSimulator` overrides `draw_scene()` to render the scene (robot FK, points, tubes, walls) with `dqrobotics-pyplot`.
- `scenes/example.yaml`: the TRO2022-like scene (robot, 4 walls, 2 tubes, `xd0`/`xd1`).
- Visualization deps are imported **lazily** and provided as an optional `viz` extra, so the base package stays headless and CI-compatible (`pip install .` unchanged).
- README: short "Optional scene visualization" section.

## Verification

- Clean C++ build (`adaptive_control_cpp` + `_core`); headless C++ example runs with the expected adaptation error (~0.13 m final task translation error).
- `adaptive_control_import_eval.py` exits 0.
- `issubclass(M3_SimulatorDummy, M3_Simulator)` → `True`; a Python `M3_Simulator` subclass is dispatched through the trampoline; a non-overriding subclass falls back to the C++ no-op.
- `M3_VFI` accepts both the C++ `M3_SimulatorDummy` and a Python `M3_Simulator` subclass, and reports the **same** distance (0.2 m) for both — confirming the `shared_ptr<M3_Simulator>` polymorphism is correct.
- `M3_PyPlotSimulator` loads `scenes/example.yaml` and renders it with `dqrobotics-pyplot` (headless Agg → PNG); the wall/tube plane-and-line DQs match the `M3_VFI` conventions, and a `M3_VFI` on the loaded scene matches the reference scene's distance.

## Example

```python
from marinholab.papers.tro2022.adaptive_control import M3_PyPlotSimulator
import matplotlib.pyplot as plt

sim = M3_PyPlotSimulator()
sim.load_scene("scenes/example.yaml")
fig = plt.figure(); plt.axes(projection="3d")
sim.draw_scene()      # overrides M3_Simulator.draw_scene()
plt.show()
```

---
*This PR was created by an AI agent (OpenHands) on behalf of the repository owner.*
